### PR TITLE
Prevent server.address() being called prematurely

### DIFF
--- a/packages/web/src/run.ts
+++ b/packages/web/src/run.ts
@@ -13,9 +13,10 @@ type WebRunOptions = {
 const webRun : IRun = function ({ app, config = {}, port = 8000 } : WebRunOptions) {
     const server = serve(app, config).listen(port);
 
-    const address = server.address() as AddressInfo;
-
-    processState.setInfo(`Serving ${chalk.blue(app)} at ${chalk.green(`http://localhost:${address.port}`)}`);
+    server.on('listening', () => {
+        const address = server.address() as AddressInfo;
+        processState.setInfo(`Serving ${chalk.blue(app)} at ${chalk.green(`http://localhost:${address.port}`)}`);
+    });
 
     // Never resolves, to let the CLI hang while the server runs
     return new Promise(() => {});


### PR DESCRIPTION
Per https://nodejs.org/api/net.html#net_server_address

    Don't call server.address() until the 'listening' event has been emitted.