### PR TITLE
 SX-293 Adding -C, --override-app-config option

### DIFF
--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -71,7 +71,7 @@ export function agregateArgv(argv : IArgv, platformId : string, command : string
 }
 
 export function addConfig(opts : any) : IOptions {
-    const config = ConfigLoader.load(opts.app, opts.env);
+    const config = ConfigLoader.load(opts.app, opts.env, opts['override-app-config']);
     config.BUILD_NUMBER = process.env.BUILD_NUMBER ? parseInt(process.env.BUILD_NUMBER, 10) : opts.buildNumber;
     opts.config = config;
     return opts;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -7,4 +7,5 @@ export interface ISywac {
     positional(flags : string, opts : any);
     string(flags : string, opts : any);
     style(opts : any);
+    array(flags : any, opts? : any);
 }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -53,6 +53,22 @@ suite('ConfigLoader', () => {
             assert.equal(result.APP_NAME, mocker.files.default.APP_NAME);
             assert.equal(result.APP_ID, mocker.files.staging.APP_ID);
         });
+        test('override existing key', () => {
+            mockConfig(fakeAppDir, {
+                default: { APP_NAME: 'default' },
+                staging: { APP_ID: 'staging', FOO: { BAR: 5 } },
+            }, '1.0.0');
+            const result = ConfigLoader.load(fakeAppDir, 'staging', { FOO: { BAR: 6 } });
+            assert.equal(result.FOO.BAR, 6);
+        });
+        test('override new key', () => {
+            mockConfig(fakeAppDir, {
+                default: { APP_NAME: 'default' },
+                staging: { APP_ID: 'staging' },
+            }, '1.0.0');
+            const result = ConfigLoader.load(fakeAppDir, 'staging', { FOO: { BAR: 7 } });
+            assert.equal(result.FOO.BAR, 7);
+        });
     });
     teardown(() => {
         mockFS.restore();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as deepMerge from 'deepmerge';
-import { IKashConfig } from './types';
+import { IKashConfig, IConfigOverrides } from './types';
 
 const DEFAULTS = {
     APP_NAME: 'Unnamed App',
@@ -24,7 +24,7 @@ function softRequire(moduleId : string, fallback = {}) : any {
 }
 
 export class ConfigLoader {
-    static load(appDir : string, env : string = 'development') : IKashConfig {
+    static load(appDir : string, env : string = 'development', overrides? : IConfigOverrides) : IKashConfig {
         const configDir = path.join(appDir, 'config');
         const defaultConfig = softRequire(path.join(configDir, 'default.json'));
         const envConfig = softRequire(path.join(configDir, `${env}.json`));
@@ -39,6 +39,8 @@ export class ConfigLoader {
         // Property used to be called UI_VERSION, alias it for backward compatibility
         config.UI_VERSION = config.VERSION;
 
-        return deepMerge<IKashConfig>(DEFAULTS, config);
+        const merged = deepMerge<IKashConfig>(DEFAULTS, config);
+
+        return deepMerge<IKashConfig>(merged, overrides);
     }
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,7 +24,7 @@ function softRequire(moduleId : string, fallback = {}) : any {
 }
 
 export class ConfigLoader {
-    static load(appDir : string, env : string = 'development', overrides? : IConfigOverrides) : IKashConfig {
+    static load(appDir : string, env : string = 'development', overrides : IConfigOverrides = {}) : IKashConfig {
         const configDir = path.join(appDir, 'config');
         const defaultConfig = softRequire(path.join(configDir, 'default.json'));
         const envConfig = softRequire(path.join(configDir, `${env}.json`));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,6 +62,10 @@ export interface IKashConfig {
     BACKGROUND_COLOR? : string;
 }
 
+export interface IConfigOverrides {
+    [propName : string] : any;
+}
+
 export interface IOptions {
     app : string;
     config : IKashConfig;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,7 @@ export interface IKashConfig {
     APP_SRC? : string;
     BUILD_NUMBER? : string;
     BACKGROUND_COLOR? : string;
+    [propName : string] : any;
 }
 
 export interface IConfigOverrides {


### PR DESCRIPTION
This allows the user to override app configuration from the command line
when using the build, run and test commands.

You can override as many keys as you need using the following
convention: `-C key.subkey=value`

```
kash run web . -C PROFILE=wand -C ICONS.WINDOWS=whatever.png
```