### PR TITLE
Update es6-resolution

### DIFF
--- a/packages/electron/app/lib/post-process.js
+++ b/packages/electron/app/lib/post-process.js
@@ -1,5 +1,5 @@
 const { Readable } = require('stream');
-const upgradeBody = require('@kano/es6-resolution');
+const { resolveNamedPath } = require('@kano/es6-resolution');
 
 module.exports = (rootDir) => {
     return (stream, mime, url) => {
@@ -10,7 +10,7 @@ module.exports = (rootDir) => {
         const final = new Readable({});
         stream.on('data', d => buffer += d.toString());
         stream.on('end', () => {
-            const newBody = upgradeBody(rootDir, buffer, mime, stream.path, url.path);
+            const newBody = resolveNamedPath(rootDir, buffer, mime, stream.path);
             final.push(newBody);
             final.push(null);
         });

--- a/packages/electron/app/package.json
+++ b/packages/electron/app/package.json
@@ -15,7 +15,7 @@
     "@kano/desktop-shell": "^1.0.8",
     "@kano/devices-sdk": "git+ssh://git@github.com:KanoComputing/kano-devices-sdk#^1.0.30",
     "@kano/electron-updater": "^1.0.0",
-    "@kano/es6-resolution": "^1.0.14",
+    "@kano/es6-resolution": "^1.0.18",
     "bufferutil": "^4.0.1",
     "minimist": "^1.2.0",
     "noble": "^1.9.1",

--- a/packages/electron/app/yarn.lock
+++ b/packages/electron/app/yarn.lock
@@ -34,10 +34,10 @@
   resolved "https://registry.yarnpkg.com/@kano/electron-updater/-/electron-updater-1.0.0.tgz#451f39286c70869483253f858654eb3da5603bca"
   integrity sha1-RR85KGxwhpSDJT+FhlTrPaVgO8o=
 
-"@kano/es6-resolution@^1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@kano/es6-resolution/-/es6-resolution-1.0.14.tgz#6afbba8e1f9647f311fb580789c7b7efd6d495a7"
-  integrity sha512-jqJzM2Qlti3snpYb71a7VEN7Idpl9hFLUGHYzZoj5L7heHSigVzv1KKb1G1AwkFldjusreFcKHk63bCF+cf6MQ==
+"@kano/es6-resolution@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@kano/es6-resolution/-/es6-resolution-1.0.18.tgz#5060e7ae55be635db5f1c69440dd857b27b45427"
+  integrity sha512-DEHPkeSnofp9nbxNsQpIghmWivNi0s3xxpqDz9a0Zu+2OZDe/gQwXLykJSJc6XMzTGtzm5fy/wISgRxzL1AMpQ==
   dependencies:
     resolve "^1.7.1"
 


### PR DESCRIPTION
 - Use newer version of es6-resolution for electron (Covers all es6 import syntax, faster regexp)