### PR TITLE
SX-1209 web: Adding additionalResources option

### DIFF
--- a/packages/web/src/build.ts
+++ b/packages/web/src/build.ts
@@ -5,6 +5,7 @@ import * as rimrafCb from 'rimraf';
 import { IBuild, IBuildOptions, IKashConfig } from '@kano/kit-app-shell-core/lib/types';
 import { copyPolyfills, generateElements } from '@kano/kit-app-shell-core/lib/util/polyfills';
 import { scripts } from './polyfills';
+import { copyResources } from './copy-resources';
 
 const rimraf = promisify(rimrafCb);
 
@@ -24,8 +25,10 @@ const webBuild : IBuild = function build(opts : WebBuildOptions) {
         replaces = [],
         targets = {},
         babelExclude = [],
+        additionalResources = [],
     } = opts;
     return rimraf(out)
+        .then(() => copyResources(additionalResources, out, app))
         .then(() => copyPolyfills(scripts, out))
         .then((names) => Bundler.bundle(
             `${__dirname}/../www/index.html`,

--- a/packages/web/src/build.ts
+++ b/packages/web/src/build.ts
@@ -5,15 +5,17 @@ import * as rimrafCb from 'rimraf';
 import { IBuild, IBuildOptions, IKashConfig } from '@kano/kit-app-shell-core/lib/types';
 import { copyPolyfills, generateElements } from '@kano/kit-app-shell-core/lib/util/polyfills';
 import { scripts } from './polyfills';
-import { copyResources } from './copy-resources';
+import { copyResources, IResources } from './copy-resources';
 
 const rimraf = promisify(rimrafCb);
 
-type WebBuildOptions = IBuildOptions;
+interface IWebBuildOptions extends IBuildOptions {
+    additionalResources? : IResources;
+}
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 
-const webBuild : IBuild = function build(opts : WebBuildOptions) {
+const webBuild : IBuild = function build(opts : IWebBuildOptions) {
     const {
         app,
         config = {} as IKashConfig,

--- a/packages/web/src/copy-resources.ts
+++ b/packages/web/src/copy-resources.ts
@@ -2,9 +2,21 @@
 import * as path from 'path';
 import { copy } from '@kano/kit-app-shell-core/lib/util/fs';
 
-export function copyResources(resources : string[], dest : string, basePath : string) {
-    const tasks = resources.map((file) => {
-        return copy(path.join(basePath, file), path.join(dest, file));
+export type IResources = Array<string | { src : string, dest : string }>;
+
+export function copyResources(resources : IResources, dest : string, basePath : string) {
+    const tasks = resources.map((res) => {
+        let relativeSrc;
+        let relativeDest;
+
+        if (typeof res === 'string') {
+            relativeSrc = res;
+            relativeDest = res;
+        } else {
+            relativeSrc = res.src;
+            relativeDest = res.dest;
+        }
+        return copy(path.join(basePath, relativeSrc), path.join(dest, relativeDest));
     });
     return Promise.all(tasks);
 }

--- a/packages/web/src/copy-resources.ts
+++ b/packages/web/src/copy-resources.ts
@@ -1,0 +1,10 @@
+
+import * as path from 'path';
+import { copy } from '@kano/kit-app-shell-core/lib/util/fs';
+
+export function copyResources(resources : string[], dest : string, basePath : string) {
+    const tasks = resources.map((file) => {
+        return copy(path.join(basePath, file), path.join(dest, file));
+    });
+    return Promise.all(tasks);
+}

--- a/packages/web/src/run.ts
+++ b/packages/web/src/run.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { getCachePath } from '@kano/kit-app-shell-core/lib/tmp';
 
 import { promisify } from 'util';
-import { copyResources } from './copy-resources';
+import { copyResources, IResources } from './copy-resources';
 
 const rimraf = promisify(rimrafCb);
 
@@ -18,7 +18,7 @@ interface IWebRunOptions {
     app : string;
     config : any;
     port : number;
-    additionalResources? : string[];
+    additionalResources? : IResources;
 }
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';

--- a/packages/web/src/run.ts
+++ b/packages/web/src/run.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { getCachePath } from '@kano/kit-app-shell-core/lib/tmp';
 
 import { promisify } from 'util';
+import { copyResources } from './copy-resources';
 
 const rimraf = promisify(rimrafCb);
 
@@ -17,17 +18,24 @@ interface IWebRunOptions {
     app : string;
     config : any;
     port : number;
+    additionalResources? : string[];
 }
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 
 const webRun : IRun = (opts : IWebRunOptions) => {
-    const { app, config = {}, port = 8000 } = opts;
+    const {
+        app,
+        config = {},
+        port = 8000,
+        additionalResources = [],
+    } = opts;
 
     const tmp = path.join(getCachePath(), 'web');
 
     // Build the shell in a tmp directory. This is required to get all native APIs working
     return rimraf(tmp)
+        .then(() => copyResources(additionalResources, tmp, app))
         .then(() => Bundler.bundle(
             `${__dirname}/../www/index.html`,
             `${__dirname}/../www/shell.js`,


### PR DESCRIPTION
Allows adding `additionalResources` to the web config with files that will be copied over into the bundle.

```js
{
    web: {
        run: {
            additionalResources: {
                'file1.html',
                'folder/file2.html',
            }
        },
        build: {
            additionalResources: {
                'file1.html',
                'folder/file2.html',
            }
        }
    }
}
```