### PR TITLE
Prompt to move to the applications folder

### DIFF
--- a/packages/electron/app/lib/app.js
+++ b/packages/electron/app/lib/app.js
@@ -1,3 +1,4 @@
+const { moveToApplicationsFolderIfNecessary } = require('./util/macos');
 const { app, ipcMain } = require('electron');
 const { Shell } = require('@kano/desktop-shell');
 const updaterBusAdapter = require('./bus/updater');
@@ -122,6 +123,7 @@ class App {
             // Subsequent windows, just update the window reference in the bus
             this.bus.setWindow(shell.window);
         }
+        moveToApplicationsFolderIfNecessary(this.shell.window, this.config.FORCE_MOVE_TO_APPLICATIONS_PROMPT);
     }
 }
 

--- a/packages/electron/app/lib/util/macos.js
+++ b/packages/electron/app/lib/util/macos.js
@@ -1,0 +1,27 @@
+const os = require('os');
+const { app, dialog } = require('electron');
+
+function moveToApplicationsFolderIfNecessary(window, force = false) {
+    if (!force && (os.platform() !== 'darwin' || !app.isPackaged)) {
+        return;
+    }
+    if (!app.isInApplicationsFolder()) {
+        setTimeout(() => {
+            const button = dialog.showMessageBox(window, {
+                type: 'question',
+                buttons: ['Move now', 'No, thank you'],
+                defaultId: 0,
+                cancelId: 1,
+                title: 'Move to the Applications folder',
+                message: 'Looks like this app is not in the Applications folder. Updates might not work until you move it.',
+            });
+            if (button === 0) {
+                app.moveToApplicationsFolder();
+            }
+        }, 1000);
+    }
+}
+
+module.exports = {
+    moveToApplicationsFolderIfNecessary,
+}

--- a/packages/electron/app/lib/util/macos.js
+++ b/packages/electron/app/lib/util/macos.js
@@ -6,6 +6,8 @@ function moveToApplicationsFolderIfNecessary(window, force = false) {
         return;
     }
     if (!app.isInApplicationsFolder()) {
+        // Wrap in a timeout. The whole windowing system of macos
+        // breaks if you don't do that
         setTimeout(() => {
             const button = dialog.showMessageBox(window, {
                 type: 'question',


### PR DESCRIPTION
 - Check if it's on mac, in a bundled app, and not in the applications folder
 - Prompt to move it
 - Add a `FORCE_MOVE_TO_APPLICATIONS_PROMPT` option to test it locally