### PR TITLE
[DO NOT MERGE] Add AppExecutionAlias extension to the app for cmdline launch

### DIFF
--- a/packages/uwp/src/extensions.ts
+++ b/packages/uwp/src/extensions.ts
@@ -1,8 +1,10 @@
+import { AppExecutionAliasProvider } from './extensions/app-execution-alias.js'
 import { FileTypeAssociationProvider } from './extensions/file-type-association.js';
 import { IExtensionProvider } from './extensions/extension.js';
 import { ShareTargetProvider } from './extensions/share-target.js';
 
 export const extensions : { [K : string] : IExtensionProvider } = {
+    APP_EXECUTION_ALIAS: AppExecutionAliasProvider,
     FILE_TYPE_ASSOCIATION: FileTypeAssociationProvider,
     SHARE_TARGET: ShareTargetProvider,
 };

--- a/packages/uwp/src/extensions/app-execution-alias.ts
+++ b/packages/uwp/src/extensions/app-execution-alias.ts
@@ -1,0 +1,15 @@
+import { IExtensionDefinition, IExtensionProvider } from './extension.js';
+
+export interface IAppExecutionAliasDefinition extends IExtensionDefinition {
+    DISPLAY_NAME : string;
+}
+
+export const AppExecutionAliasProvider : IExtensionProvider = {
+    render(definition: IAppExecutionAliasDefinition) {
+        return `
+            <uap5:AppExecutionAlias>
+                <uap5:ExecutionAlias Alias="${definition.DISPLAY_NAME}.exe" />
+            </uap5:AppExecutionAlias>
+        `;
+    },
+};

--- a/packages/uwp/template/_Project/package.appxmanifest
+++ b/packages/uwp/template/_Project/package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap5">
   <Identity Name="${PACKAGE_NAME}" Version="${VERSION}.0" Publisher="${PUBLISHER}" />
   <mp:PhoneIdentity PhoneProductId="03ed9448-2c14-49ef-bce4-552585be80aa" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>


### PR DESCRIPTION
The extensions registers an executable alias for the UWP app which
can be used from Powershell or Command Prompt to launch the app.
Additional support can be made in order to interpret command line
parameters when launching the app. This may be useful for debugging
and development.

---

Note:

Used [this article](https://blogs.windows.com/windowsdeveloper/2017/07/05/command-line-activation-universal-windows-apps/) for reference. Also tried the extension to Kano Hub and was able to launch it simply from Powershell.

**However, as mentioned in the article, the arguments need to be handled and if it does work, the app might open with a blank page.**

Let's build this and test with your app and see how it reacts to the args you were trying to pass to it.